### PR TITLE
Fix did.json generation

### DIFF
--- a/cmd/gendid.go
+++ b/cmd/gendid.go
@@ -44,7 +44,7 @@ func generateDid(cmd *cobra.Command, args []string) error {
 		Id:          "did:web:" + handle,
 		AlsoKnownAs: []string{"at://" + handle},
 		VerificationMethod: []*VerificationMethod{{
-			ID:                 "did:web:" + handle + "#athandle",
+			ID:                 "did:web:" + handle + "#atproto",
 			Type:               "Multikey",
 			Controller:         "did:web:" + handle,
 			PublicKeyMultibase: pubkey,


### PR DESCRIPTION
Fix id so that it can be found by getSigningKey in https://github.com/bluesky-social/atproto/blob/d643b5bb13e98275a7319bffdc9e89ac0e6a9c00/packages/common-web/src/did-doc.ts