### PR TITLE
Adds --lxm option to sign command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+didweb


### PR DESCRIPTION
The `lxm` claim is now needed in the JWT for certain operations.

Example:
```
TOKEN=$(./didweb sign --privkey $PRIVKEY --iss did:web:name.example.com --aud did:web:pds.example.com --exp 180 --lxm com.atproto.server.createAccount)
```

Also added the generated binary to `.gitignore`.